### PR TITLE
Build also with psc-package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /output/
 /.psci*
 /src/.webpack.js
+/.psc-package

--- a/psc-package-dev.json
+++ b/psc-package-dev.json
@@ -1,0 +1,10 @@
+{
+    "name": "purescript-mmorph",
+    "set": "psc-0.11.4",
+    "source": "https://github.com/purescript/package-sets.git",
+    "depends":
+    [       "console",
+            "functors",
+            "transformers"
+    ]
+}

--- a/psc-package-dist.json
+++ b/psc-package-dist.json
@@ -1,0 +1,10 @@
+{
+    "name": "purescript-mmorph",
+    "set": "psc-0.11.4",
+    "source": "https://github.com/purescript/package-sets.git",
+    "depends":
+    [
+            "functors",
+            "transformers"
+    ]
+}

--- a/psc-package.json
+++ b/psc-package.json
@@ -1,0 +1,10 @@
+{
+    "name": "purescript-mmorph",
+    "set": "psc-0.11.4",
+    "source": "https://github.com/purescript/package-sets.git",
+    "depends":
+    [
+            "functors",
+            "transformers"
+    ]
+}

--- a/psc-package.json
+++ b/psc-package.json
@@ -1,10 +1,1 @@
-{
-    "name": "purescript-mmorph",
-    "set": "psc-0.11.4",
-    "source": "https://github.com/purescript/package-sets.git",
-    "depends":
-    [
-            "functors",
-            "transformers"
-    ]
-}
+psc-package-dist.json


### PR DESCRIPTION
json files for dev and dist included.

```
psc-package update
psc-packabe build
```
should build (I'm using purescript-spec, which depends on -pipes, which depends on -mmorph and I'd like to use psc-package instead of bower).