### PR TITLE
Migrate to PureScript 0.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,11 +17,11 @@
   },
   "license": "MIT",
   "dependencies": {
-    "purescript-transformers": "^4.0.0",
-    "purescript-functors": "^3.0.0",
-    "purescript-free": "^5.1.0"
+    "purescript-transformers": "^5.0.0",
+    "purescript-functors": "^4.0.0",
+    "purescript-free": "^6.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^4.1.0"
+    "purescript-console": "^5.0.0"
   }
 }

--- a/src/Control/Monad/Morph.purs
+++ b/src/Control/Monad/Morph.purs
@@ -26,7 +26,7 @@ import Data.Newtype (over, unwrap)
 import Data.Tuple (Tuple(..))
 import Data.Yoneda (Yoneda, hoistYoneda, lowerYoneda)
 
-class MFunctor t where
+class MFunctor (t :: (Type -> Type) -> Type -> Type) where
   hoist :: forall m n. Monad m => m ~> n -> t m ~> t n
 
 instance mfunctorExceptT :: MFunctor (E.ExceptT e) where


### PR DESCRIPTION
This PR updates dependencies in the Bower file to those in the current psc-0.14.0 package set and makes necessary changes to compile with PureScript 0.14.0 (just one change, and even that was just a warning about polymorphic inferred kind).

This is required in order to upgrade some downstream packages, which still rely on Bower for dependencies.